### PR TITLE
fix re-rendered to restart event

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -195,8 +195,10 @@ loop do
             state =
               case task_event_type
               when "Restart Signaled"
-                if task_event_details.dig("restart_reason").match?(/unhealthy/)
+                if task_event_details.dig("restart_reason")&.match?(/unhealthy/)
                   :failure
+                else
+                  :success
                 end
               when "Terminated"
                 if task_event_details.dig("oom_killed") == "true"


### PR DESCRIPTION
Fix re-rendered to restart event, such like change template content via consul etc, response data: 

```json
{
    "Type": "Restart Signaled", 
    "Time": 1691823192922288000, 
    "Message": "", 
    "DisplayMessage": "Template with change_mode restart re-rendered", 
    "Details": { }, 
    "FailsTask": false, 
    "RestartReason": "", 
    "SetupError": "", 
    "DriverError": "", 
    "ExitCode": 0, 
    "Signal": 0, 
    "KillTimeout": 0, 
    "KillError": "", 
    "KillReason": "", 
    "StartDelay": 0, 
    "DownloadError": "", 
    "ValidationError": "", 
    "DiskLimit": 0, 
    "FailedSibling": "", 
    "VaultError": "", 
    "TaskSignalReason": "", 
    "TaskSignal": "", 
    "DriverMessage": "", 
    "GenericSource": ""
}
```